### PR TITLE
Also include a reference to standard-layout types

### DIFF
--- a/doc/classes/dynamic_vector_buffer.qbk
+++ b/doc/classes/dynamic_vector_buffer.qbk
@@ -42,7 +42,7 @@ requirements.dynamic_buffers `DynamicBufferSequence`].
   } // namespace std
 
 The `dynamic_vector_buffer` class template requires that `T` is a trivially
-copyable type and that `sizeof(T) == 1`.
+copyable or standard-layout type, and that `sizeof(T) == 1`.
 
 [section [^dynamic_vector_buffer] constructors]
 [xrefid buffer.dynamic.vector.cons]

--- a/doc/functions/buffer.qbk
+++ b/doc/functions/buffer.qbk
@@ -1,7 +1,8 @@
 [section:buffer Buffer creation functions]
 [xrefid buffer.creation]
 
-In the functions below, `T` must be a trivially copyable type.
+In the functions below, `T` must be a trivially copyable or standard-layout
+type.
 
 For the function overloads below that accept an argument of type `vector<>`,
 the buffer objects returned are invalidated by any vector operation that also


### PR DESCRIPTION
Possibly fixes #88 - I'm unclear from the standard if the addition of standard-layout types
is redundant and not required -  see related comments in the issue.
