### PR TITLE
[internet.resolver.ops] cast void* to sockaddr*

### DIFF
--- a/doc/classes/ip__basic_resolver.qbk
+++ b/doc/classes/ip__basic_resolver.qbk
@@ -297,17 +297,17 @@ Resolves an endpoint as if by __POSIX__:
   int flags = 0;
   if (endpoint_type().protocol().type() == SOCK_DGRAM)
     flags |= NI_DGRAM;
-  int result = __getnameinfo__(e.data(), e.size(),
-                               host_name, S1,
-                               service_name, S2,
-                               flags);
+  int result = __getnameinfo__((const sockaddr*)e.data(), e.size(),
+                           host_name, S1,
+                           service_name, S2,
+                           flags);
   if (result != 0)
   {
     flags |= NI_NUMERICSERV;
-    result = __getnameinfo__(e.data(), e.size(),
-                             host_name, S1,
-                             service_name, S2,
-                             flags);
+    result = __getnameinfo__((const sockaddr*)e.data(), e.size(),
+                         host_name, S1,
+                         service_name, S2,
+                         flags);
   }
 ``]
 
@@ -329,17 +329,17 @@ Initiates an asynchronous operation to resolve an endpoint as if by __POSIX__:
   int flags = 0;
   if (endpoint_type().protocol().type() == SOCK_DGRAM)
     flags |= NI_DGRAM;
-  int result = __getnameinfo__(e.data(), e.size(),
-                               host_name, S1,
-                               service_name, S2,
-                               flags);
+  int result = __getnameinfo__((const sockaddr*)e.data(), e.size(),
+                           host_name, S1,
+                           service_name, S2,
+                           flags);
   if (result != 0)
   {
     flags |= NI_NUMERICSERV;
-    result = __getnameinfo__(e.data(), e.size(),
-                             host_name, S1,
-                             service_name, S2,
-                             flags);
+    result = __getnameinfo__((const sockaddr*)e.data(), e.size(),
+                         host_name, S1,
+                         service_name, S2,
+                         flags);
   }
 ``
 On success, `r` is a results object with `size() == 1` containing the results


### PR DESCRIPTION
getnameinfo expects const sockaddr*.

Also adjust indentation to account for double-underscore markup on getnameinfo.
